### PR TITLE
Automatic Table of Contents generation

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -8,7 +8,121 @@
 defined by [the specification](spec.md). If you are writing a server
 implementation, please refer to that document also.**
 
+
+<details><summary><b>Table of contents</b></summary>
+
+<!-- toc -->
+
+- [Transport](#transport)
+    + [HTTP(S) endpoints - For client->server requests](#https-endpoints---for-client-server-requests)
+    + [WebSocket events - For server->client event notifications](#websocket-events---for-server-client-event-notifications)
+- [Authentication](#authentication)
+  * [With HTTP(S) - per-request](#with-https---per-request)
+- [With WebSockets - ping/pong periodically](#with-websockets---pingpong-periodically)
+  * ['pingdata' evemt](#pingdata-evemt)
+- ['pongdata' event](#pongdata-event)
+- [Errors](#errors)
+- [Permissions](#permissions)
+- [Miscellaneous](#miscellaneous)
+  * [Endpoints](#endpoints)
+    + [Retrieve server implementation details [GET /api]](#retrieve-server-implementation-details-get-api)
+    + [Upload an image [POST /api/upload-image]](#upload-an-image-post-apiupload-image)
+- [Settings](#settings)
+  * [Events](#events)
+    + [server-settings/update](#server-settingsupdate)
+  * [Endpoints](#endpoints-1)
+    + [Retrieve all settings [GET /api/settings]](#retrieve-all-settings-get-apisettings)
+    + [Modify settings [PATCH /api/settings]](#modify-settings-patch-apisettings)
+- [Emotes](#emotes)
+  * [Events](#events-1)
+    + [emote/new](#emotenew)
+    + [emote/delete](#emotedelete)
+  * [Endpoints](#endpoints-2)
+    + [List emotes [GET /api/emotes]](#list-emotes-get-apiemotes)
+    + [Add a new emote [POST /api/emotes]](#add-a-new-emote-post-apiemotes)
+    + [View an emote [GET /api/emotes/:shortcode]](#view-an-emote-get-apiemotesshortcode)
+    + [Delete an existing emote [DELETE /api/emotes/:shortcode]](#delete-an-existing-emote-delete-apiemotesshortcode)
+- [Sessions](#sessions)
+  * [Endpoints](#endpoints-3)
+    + [Fetch the current user's sessions [GET /api/sessions]](#fetch-the-current-users-sessions-get-apisessions)
+    + [Login [POST /api/sessions]](#login-post-apisessions)
+    + [Fetch session details [GET /api/sessions/:id]](#fetch-session-details-get-apisessionsid)
+    + [Logout [DELETE /api/sessions/:id]](#logout-delete-apisessionsid)
+- [Messages](#messages)
+    + [Message types](#message-types)
+    + [Mentions](#mentions)
+  * [Events](#events-2)
+    + [message/new](#messagenew)
+    + [message/edit](#messageedit)
+    + [message/delete](#messagedelete)
+  * [Endpoints](#endpoints-4)
+    + [Send a message [POST /api/messages]](#send-a-message-post-apimessages)
+    + [Retrieve a message [GET /api/messages/:id]](#retrieve-a-message-get-apimessagesid)
+    + [Edit a message [PATCH /api/messages/:id]](#edit-a-message-patch-apimessagesid)
+    + [Delete a message [DELETE /api/messages/:id]](#delete-a-message-delete-apimessagesid)
+- [Channels](#channels)
+    + [Extra data](#extra-data)
+  * [Events](#events-3)
+    + [channel/new](#channelnew)
+    + [channel/update](#channelupdate)
+    + [channel/pins/add](#channelpinsadd)
+    + [channel/pins/remove](#channelpinsremove)
+    + [channel/delete](#channeldelete)
+  * [Endpoints](#endpoints-5)
+    + [Get list of channels [GET /api/channels]](#get-list-of-channels-get-apichannels)
+    + [Create a channel [POST /api/channels]](#create-a-channel-post-apichannels)
+    + [Retrieve a channel [GET /api/channels/:id]](#retrieve-a-channel-get-apichannelsid)
+    + [Rename a channel [PATCH /api/channels/:id]](#rename-a-channel-patch-apichannelsid)
+    + [Delete a channel [DELETE /api/channels/:id]](#delete-a-channel-delete-apichannelsid)
+    + [Mark a channel as read [POST /api/channels/:id/mark-read]](#mark-a-channel-as-read-post-apichannelsidmark-read)
+    + [Get messages in channel [GET /api/channels/:id/messages]](#get-messages-in-channel-get-apichannelsidmessages)
+    + [Update channel-specific role permissions [PATCH /api/channels/:id/role-permissions]](#update-channel-specific-role-permissions-patch-apichannelsidrole-permissions)
+    + [Get channel-specific role permissions [GET /api/channels/:id/role-permissions]](#get-channel-specific-role-permissions-get-apichannelsidrole-permissions)
+    + [Retrieve all pinned messages [GET /api/channels/:id/pins]](#retrieve-all-pinned-messages-get-apichannelsidpins)
+    + [Pin a message [POST /api/channels/:id/pins]](#pin-a-message-post-apichannelsidpins)
+    + [Unpin a message [DELETE /api/channels/:channelID/pins/:messageID]](#unpin-a-message-delete-apichannelschannelidpinsmessageid)
+- [Users](#users)
+  * [Events](#events-4)
+    + [user/new](#usernew)
+    + [user/delete](#userdelete)
+    + [user/online](#useronline)
+    + [user/offline](#useroffline)
+    + [user/update](#userupdate)
+    + [user/mentions/add](#usermentionsadd)
+    + [user/mentions/remove](#usermentionsremove)
+  * [Endpoints](#endpoints-6)
+  * [Fetch users [GET /api/users]](#fetch-users-get-apiusers)
+    + [Register (create new user) [POST /api/users]](#register-create-new-user-post-apiusers)
+    + [Retrieve a user by ID [GET /api/users/:id]](#retrieve-a-user-by-id-get-apiusersid)
+    + [List mentions of a user [GET /api/users/:id/mentions]](#list-mentions-of-a-user-get-apiusersidmentions)
+    + [Update user details [PATCH /api/users/:id]](#update-user-details-patch-apiusersid)
+    + [Retrieve a user by ID [GET /api/users/:id]](#retrieve-a-user-by-id-get-apiusersid-1)
+    + [Get a user's permissions [GET /api/users/:id/permissions]](#get-a-users-permissions-get-apiusersidpermissions)
+    + [Get a user's channel-specific permissions [GET /api/users/:userID/channel-permissions/:channelID]](#get-a-users-channel-specific-permissions-get-apiusersuseridchannel-permissionschannelid)
+    + [Delete a user [DELETE /api/users/:id]](#delete-a-user-delete-apiusersid)
+    + [Check if a username is available [GET /api/username-available/:username]](#check-if-a-username-is-available-get-apiusername-availableusername)
+- [Roles](#roles)
+    + [See also](#see-also)
+  * [Events](#events-5)
+    + [role/new](#rolenew)
+    + [role/update](#roleupdate)
+    + [role/delete](#roledelete)
+  * [Endpoints](#endpoints-7)
+    + [List roles [GET /api/roles]](#list-roles-get-apiroles)
+    + [Retrieve role prioritization order [GET /api/roles/order]](#retrieve-role-prioritization-order-get-apirolesorder)
+    + [Change role prioritization order [PATCH /api/roles/order]](#change-role-prioritization-order-patch-apirolesorder)
+    + [Retrieve a role by ID [GET /api/roles/:id]](#retrieve-a-role-by-id-get-apirolesid)
+    + [Add a new role [POST /api/roles]](#add-a-new-role-post-apiroles)
+    + [Update a role [PATCH /api/roles/:id]](#update-a-role-patch-apirolesid)
+    + [Delete a role [DELETE /api/roles/:id]](#delete-a-role-delete-apirolesid)
+
+<!-- tocstop -->
+
+</details>
+
 ---
+
+## Transport
 
 Servers support the following two forms of transport, which are meant to be used in conjunction with eachother:
 
@@ -26,7 +140,7 @@ Messages sent to and from sockets are JSON strings, following the format `{ evt,
 
 Clients should authenticate using both of the following methods at the same time.
 
-<details><summary><b>With HTTP(S)</b> - per-request</summary>
+### With HTTP(S) - per-request
 
 When a request is made to an API endpoint, the server searches for a [session ID](#sessions) string given in the request using **one** of:
 
@@ -42,15 +156,13 @@ If the request requires [permission(s)](#permissions) and a session ID is not pr
 
 Note that "you" in this document typically refers to the provided session ID's related user.
 
-</details>
+### With WebSockets - ping/pong periodically
 
-<details><summary><b>With WebSockets</b> - ping/pong periodically</summary>
-
-## pingdata
+#### 'pingdata' evemt
 
 Sent periodically (typically every 10 seconds) by the server, as well as immediately upon the client socket connecting. Clients should respond with a `pongdata` event, as described below. No `data` is sent with the event.
 
-## pongdata
+#### 'pongdata' event
 
 Should be **sent from clients** (unlike all other WebSocket transmissions) in response to `pingdata`. Notifies the server of any information related to the particular socket. Passed data should include:
 
@@ -1000,7 +1112,7 @@ GET /api/users/1
 ```
 
 <a name='get-mentions'></a>
-#### List [mentions](#mentions) of a user [GET /api/users/:id/mentions]
+#### List mentions of a user [GET /api/users/:id/mentions]
 + does not require session, however:
   * only returns messages where you have the `viewMessages` [permission](#permissions) for the message's channel
 + **in-url** id (ID) - The user ID to fetch the mentions of

--- a/doc.md
+++ b/doc.md
@@ -167,9 +167,9 @@ Below is a table of all permissions.
 
 ## Miscellaneous
 
-**Endpoints**
+### Endpoints
 
-###### Retrieve server implementation details [GET /api]
+#### Retrieve server implementation details [GET /api]
 Returns `{ decentVersion, implementation, useSecureProtocol }`, where `decentVersion` is a string version number corresponding to the specification version the server supports/providers, `implementation` is a string typically refering to the name of the server impementation, and the boolean `useSecureProtocol` should be `true` when this server is only accessible via the _HTTPS_ and _WSS_ protocols.
 
 Should be used to check to see if a particular server is compatible with the version of the spec that you (the client) support. Note that Decent follows [SemVer](https://semver.org/), so unless the MAJOR (first) portion of the version number is different to what you expect communication should work fine.
@@ -185,7 +185,7 @@ GET /api/
 ```
 
 <a id='upload-image'></a>
-###### Upload an image [POST /api/upload-image]
+#### Upload an image [POST /api/upload-image]
 + requires [permission](#permissions): `uploadImages`
 + expects form data (`multipart/form-data`)
   * `image` (gif/jpeg/png) - The image to upload. Max size: 10MB
@@ -215,16 +215,16 @@ This endpoint may return [an error](#errors), namely FAILED, NO, or NOT_ALLOWED.
 }
 ```
 
-**Events**
+### Events
 
 <a name='server-settings-update'></a>
-###### server-settings/update
+#### server-settings/update
 
 Emitted with data `{ settings }` when the server settings are modified.
 
-**Endpoints**
+### Endpoints
 
-###### Retrieve all settings [GET /api/settings]
+#### Retrieve all settings [GET /api/settings]
 Returns `{ settings }`, where `settings` is an object representing server-specific settings.
 
 ```js
@@ -238,7 +238,7 @@ GET /api/settings
 <- }
 ```
 
-###### Modify settings [PATCH /api/settings]
+#### Modify settings [PATCH /api/settings]
 + requires [permission](#permissions): `manageServer`
 + `name` (string; optional)
 + `iconURL` (string; optional)
@@ -266,23 +266,23 @@ PATCH /api/settings
 }
 ```
 
-**Events**
+### Events
 
 <a name='emote-new'></a>
-###### emote/new
+#### emote/new
 
 Sent to all clients when an emote is created. Passed data is in the format `{ emote }`.
 
 <a name='emote-delete'></a>
-###### emote/delete
+#### emote/delete
 
 Sent to all clients when an emote is deleted. Passed data is in the format `{ shortcode }`.
 
 
-**Endpoints**
+### Endpoints
 
 <a name='list-emotes'></a>
-###### List emotes [GET /api/emotes]
+#### List emotes [GET /api/emotes]
 
 Returns `{ emotes }`, where `emotes` is an array of emote objects.
 
@@ -295,7 +295,7 @@ GET /api/emotes
 ```
 
 <a name='new-emote'></a>
-###### Add a new emote [POST /api/emotes]
+#### Add a new emote [POST /api/emotes]
 + requires [permission](#permissions): `manageEmotes`
 + `imageURL` (string)
 + `shortcode` (string) - Should not include colons (`:`) or spaces. Must be unique, even if the user has the `allowNonUnique` [permission](#permissions).
@@ -314,7 +314,7 @@ POST /api/emotes
 ```
 
 <a name='view-emote'></a>
-###### View an emote [GET /api/emotes/:shortcode]
+#### View an emote [GET /api/emotes/:shortcode]
 + **in-url** shortcode (string)
 
 302 redirects to the `imageURL` of the emote specified. 404s if not found or invalid.
@@ -325,7 +325,7 @@ POST /api/emotes
 ```
 
 <a name='delete-emote'></a>
-###### Delete an existing emote [DELETE /api/emotes/:shortcode]
+#### Delete an existing emote [DELETE /api/emotes/:shortcode]
 + requires [permission](#permissions): `manageEmotes`
 + **in-url** shortcode (string)
 
@@ -348,10 +348,10 @@ DELETE /api/emotes/package
 }
 ```
 
-**Endpoints**
+### Endpoints
 
 <a name='get-sessions'></a>
-###### Fetch the current user's sessions [GET /api/sessions]
+#### Fetch the current user's sessions [GET /api/sessions]
 + requires a valid session ID & user
 
 Responds with `{ sessions }`, where `sessions` is an array of [sessions](#sessions) that also represent the user that the provided session represents (the callee; you).
@@ -370,7 +370,7 @@ GET /api/sessions
 ```
 
 <a name='login'></a>
-###### Login [POST /api/sessions]
+#### Login [POST /api/sessions]
 + `username` (string)
 + `password` (string)
 
@@ -389,7 +389,7 @@ POST /api/sessions
 <- }
 ```
 
-###### Fetch session details [GET /api/sessions/:id]
+#### Fetch session details [GET /api/sessions/:id]
 + does not require a session ID via means other than in the URL
 + **in-url** id (string, session ID)
 
@@ -412,7 +412,7 @@ GET /api/sessions/12345678-ABCDEFGH
 ```
 
 <a name='logout'></a>
-###### Logout [DELETE /api/sessions/:id]
+#### Logout [DELETE /api/sessions/:id]
 + does not require a session ID via means other than in the URL
 + **in-url** id (string, session ID)
 
@@ -465,27 +465,27 @@ System messages lack `author` fields.
 
 Mentions target a single user only and are formatted as `<@userID>`, where `userID` is the ID of the user who is being mentioned. Mentions are stored per-user on the server. `mentionedUserIDs` is derived from the content of the message.
 
-**Events**
+### Events
 
 <a name='message-new'></a>
-###### message/new
+#### message/new
 
 Sent to all clients whenever a message is [sent](#send-message) to any channel in the server. Passed data is in the format `{ message }`, where `message` is a [message](#messages) representing the new message.
 
 <a name='message-edit'></a>
-###### message/edit
+#### message/edit
 
 Sent to all clients when any message is [edited](#edit-message). Passed data is in the format `{ message }`, where `message` is a [message](#messages) representing the new message.
 
 <a name='message-delete'></a>
-###### message/delete
+#### message/delete
 
 Sent to all clients when any message is [deleted](#delete-message). Passed data is in the format `{ messageID }`.
 
-**Endpoints**
+### Endpoints
 
 <a name='send-message'></a>
-###### Send a message [POST /api/messages]
+#### Send a message [POST /api/messages]
 + requires [permissions](#permissions):
   * `sendMessages`
   * `sendSystemMessages`, if `type == "system"`
@@ -509,7 +509,7 @@ POST /api/messages
 ```
 
 <a name='get-message'></a>
-###### Retrieve a message [GET /api/messages/:id]
+#### Retrieve a message [GET /api/messages/:id]
 + requires [permission](#permissions): `readMessages`
 + **in-url** id (ID) - The ID of the message to retrieve
 
@@ -527,7 +527,7 @@ GET /api/messages/1234
 ```
 
 <a name='edit-message'></a>
-###### Edit a message [PATCH /api/messages/:id]
+#### Edit a message [PATCH /api/messages/:id]
 + requires a session ID where the session user is the author of message `id`
 + **in-url** id (ID) - The ID of the message to edit
 + `text` (string) - The new content of the message
@@ -547,7 +547,7 @@ PATCH /api/messages/1234
 This endpoint will return a NOT_YOURS [error](#errors) if you do not own the message in question. Emits [user/mentions/add](#user-mentions-add) to newly [mentioned](#mentions) users and [user/mentions/remove](#user-mentions-remove) to users who are no longer mentioned, if any.
 
 <a name='delete-message'></a>
-###### Delete a message [DELETE /api/messages/:id]
+#### Delete a message [DELETE /api/messages/:id]
 + requires one of:
   * session with ownership of message `id`
   * [permission](#permissions) (for channel of specified message) `deleteMessages`
@@ -575,7 +575,7 @@ This endpoint may return a NOT_YOURS [error](#errors) if you do not own the mess
 ```
 
 <a id='channel-extra-data'></a>
-###### Extra data
+#### Extra data
 This data is only present if a valid, logged-in session ID is provided to channel-returning endpoints.
 ```js
 {
@@ -588,37 +588,37 @@ This data is only present if a valid, logged-in session ID is provided to channe
 }
 ```
 
-**Events**
+### Events
 
 <a name='channel-new'></a>
-###### channel/new
+#### channel/new
 
 Sent to all clients when a channel is [created](#create-channel). Passed data is in the format `{ channel }`, where `channel` is a [channel](#channels) representing the new channel.
 
 <a name='channel-update'></a>
-###### channel/update
+#### channel/update
 
 Sent to all clients when a channel is updated ([renamed](#rename-channel), [marked as read](#mark-channel-as-read), etc). Passed data is in the format `{ channel }`, including `channel.unreadMessageCount` if the socket is actively [ponging sessionIDs](#pongdata).
 
 <a name='channel-pins-add'></a>
-###### channel/pins/add
+#### channel/pins/add
 
 Sent to all clients when a message is [pinned](#pin) to a channel. Passed data is in the format `{ message }`, where `message` is the message that was pinned.
 
 <a name='channel-pins-remove'></a>
-###### channel/pins/remove
+#### channel/pins/remove
 
 Sent to all clients when a message is [unpinned](#unpin) from a channel. Passed data is in the format `{ messageID }`, where `messageID` is the ID of the message that was unpinned.
 
 <a name='channel-delete'></a>
-###### channel/delete
+#### channel/delete
 
 Sent to all clients when a channel is [deleted](#delete-channel). Passed data is in the format `{ channelID }`.
 
-**Endpoints**
+### Endpoints
 
 <a name='channel-list'></a>
-###### Get list of channels [GET /api/channels]
+#### Get list of channels [GET /api/channels]
 + does not require session, however:
   * channels where the session user does not have the `readMessages` [permission](#permissions) will not be returned
   * returns [extra data](#channel-extra-data) with session
@@ -639,7 +639,7 @@ GET /api/channels
 ```
 
 <a name='create-channel'></a>
-###### Create a channel [POST /api/channels]
+#### Create a channel [POST /api/channels]
 + requires [permission](#permissions) `manageChannels`
 + `name` (name) - The name of the channel.
 
@@ -658,7 +658,7 @@ POST /api/channels
 ```
 
 <a name='get-channel'></a>
-###### Retrieve a channel [GET /api/channels/:id]
+#### Retrieve a channel [GET /api/channels/:id]
 + does not require session, however:
   * returns [extra data](#channel-extra-data) with session
 + **in-url** id (ID) - The ID of the channel.
@@ -677,7 +677,7 @@ GET /api/channels/5678
 ```
 
 <a name='rename-channel'></a>
-###### Rename a channel [PATCH /api/channels/:id]
+#### Rename a channel [PATCH /api/channels/:id]
 + requires [permission](#permissions) `manageChannels`
 + **in-url** id (ID) - The ID of the channel.
 + name (name) - The new name of the channel
@@ -695,7 +695,7 @@ PATCH /api/channels/5678
 ```
 
 <a name='delete-channel'></a>
-###### Delete a channel [DELETE /api/channels/:id]
+#### Delete a channel [DELETE /api/channels/:id]
 + requires [permission](#permissions) `manageChannels`
 + **in-url** id (ID) - The ID of the channel to delete.
 
@@ -708,7 +708,7 @@ DELETE /api/channels/5678
 ```
 
 <a name='mark-channel-as-read'></a>
-###### Mark a channel as read [POST /api/channels/:id/mark-read]
+#### Mark a channel as read [POST /api/channels/:id/mark-read]
 + requires [permission](#permissions) (for specified channel) `readMessages`
 + **in-url** id (ID) - The ID of the channel.
 
@@ -721,7 +721,7 @@ POST /api/channels/5678/mark-read
 ```
 
 <a name='get-messages-in-channel'></a>
-###### Get messages in channel [GET /api/channels/:id/messages]
+#### Get messages in channel [GET /api/channels/:id/messages]
 + requires [permission](#permissions) (for specified channel) `readMessages`
 + **in-url** id (ID) - The ID of the channel to fetch messages of.
 + `before` (ID; optional) - The ID of the message right **after** the range of messages you want.
@@ -766,7 +766,7 @@ GET /api/channels/5678/messages?after=1234
 ```
 
 <a name='update-channel-permissions'></a>
-###### Update channel-specific role permissions [PATCH /api/channels/:id/role-permissions]
+#### Update channel-specific role permissions [PATCH /api/channels/:id/role-permissions]
 + requires [permission](#permissions) (for specified channel) `manageRoles`
 + **in-url** id (ID)
 + **rolePermissions** - an object map of role IDs to their permissions
@@ -793,7 +793,7 @@ PATCH /api/channels/1234/role-permissions
 ```
 
 <a name='get-channel-permissions'></a>
-###### Get channel-specific role permissions [GET /api/channels/:id/role-permissions]
+#### Get channel-specific role permissions [GET /api/channels/:id/role-permissions]
 + **in-url** id (ID)
 
 Returns `{ rolePermissions }` if successful, where `rolePermissions` is a map of role IDs to their individual [permissions](#permissions).
@@ -813,7 +813,7 @@ GET /api/channels/1234/role-permissions
 ```
 
 <a name='get-pins'></a>
-###### Retrieve all pinned messages [GET /api/channels/:id/pins]
+#### Retrieve all pinned messages [GET /api/channels/:id/pins]
 + requires [permission](#permissions) (for specified channel) `readMessages`
 + **in-url** id (ID)
 
@@ -834,7 +834,7 @@ GET /api/channels/5678/pins
 ```
 
 <a name='pin'></a>
-###### Pin a message [POST /api/channels/:id/pins]
+#### Pin a message [POST /api/channels/:id/pins]
 + requires [permission](#permissions) (for specified channel) `managePins`
 + **in-url** id (ID)
 + `messageID` (ID) - The message to pin to this channel.
@@ -852,7 +852,7 @@ POST /api/channels/5678/pins
 ```
 
 <a name='unpin'></a>
-###### Unpin a message [DELETE /api/channels/:channelID/pins/:messageID]
+#### Unpin a message [DELETE /api/channels/:channelID/pins/:messageID]
 + requires [permission](#permissions) (for specified channel) `managePins`
 + **in-url** channelID (ID)
 + **in-url** messageID (ID) - The ID of the message to unpin. Errors if not pinned.
@@ -884,44 +884,44 @@ DELETE /api/channels/5678/pins/1234
 }
 ```
 
-**Events**
+### Events
 
 <a name='user-new'></a>
-###### user/new
+#### user/new
 
 Sent to all clients when a user is created. Passed data is in the format `{ user }`.
 
 <a name='user-delete'></a>
-###### user/delete
+#### user/delete
 
 Sent to all clients when a user is deleted. Passed data is in the format `{ userID }`.
 
 <a name='user-online'></a>
-###### user/online
+#### user/online
 
 Sent to all clients when a user becomes online. This is whenever a socket [tells the server](#pongdata) that its session ID is that of a user who was not already online before. Passed data is in the format `{ userID }`.
 
 <a name='user-offline'></a>
-###### user/offline
+#### user/offline
 
 Sent to all clients when a user becomes offline. This is whenever the last socket of a user who is online terminates. Passed data is in the format `{ userID }`.
 
 <a name='user-update'></a>
-###### user/update
+#### user/update
 
 Sent to all clients when a user is mutated using [PATCH /api/users/:userID](#update-user). Passed data is in the format `{ user }`.
 
 <a name='user-mentions-add'></a>
-###### user/mentions/add
+#### user/mentions/add
 
 When a user is [mentioned](#mentions), this is sent to all sockets authenticated as them. Passed data is in the format `{ message }`, where `message` is the new / just edited mesage that mentioned the user.
 
 <a name='user-mentions-remove'></a>
-###### user/mentions/remove
+#### user/mentions/remove
 
 When a message is deleted or edited to remove [the mention of a user](#mentions), all sockets authenticated as the unmentioned user are sent this event. Passed data is in the format `{ messageID }`, where `messageID` is the ID of the message that just stopped mentioning the user.
 
-**Endpoints**
+### Endpoints
 
 <a name='user-list'></a>
 ### Fetch users [GET /api/users]
@@ -956,7 +956,7 @@ GET /api/users?sessionID=adminsid123
 ```
 
 <a name='register'></a>
-###### Register (create new user) [POST /api/users]
+#### Register (create new user) [POST /api/users]
 + `username` ([name](#names)) - Must be unique
 + `password` (string) - Errors if shorter than 6 characters
 
@@ -980,7 +980,7 @@ POST /api/users
 ```
 
 <a name='get-user'></a>
-###### Retrieve a user by ID [GET /api/users/:id]
+#### Retrieve a user by ID [GET /api/users/:id]
 + does not require a valid session, howerver:
   * returns extra data (`email`) if the provided session represents the user requested
 + **in-url** id (ID) - The user ID to fetch
@@ -1000,7 +1000,7 @@ GET /api/users/1
 ```
 
 <a name='get-mentions'></a>
-###### List [mentions](#mentions) of a user [GET /api/users/:id/mentions]
+#### List [mentions](#mentions) of a user [GET /api/users/:id/mentions]
 + does not require session, however:
   * only returns messages where you have the `viewMessages` [permission](#permissions) for the message's channel
 + **in-url** id (ID) - The user ID to fetch the mentions of
@@ -1027,7 +1027,7 @@ GET /api/users/1/mentions?limit=1
 ```
 
 <a name='update-user'></a>
-###### Update user details [PATCH /api/users/:id]
+#### Update user details [PATCH /api/users/:id]
 + requires valid, logged-in session (see below)
 + **in-url** id (ID) - The user ID to patch
 
@@ -1079,7 +1079,7 @@ PATCH /api/users/12
 ```
 
 <a name='get-user'></a>
-###### Retrieve a user by ID [GET /api/users/:id]
+#### Retrieve a user by ID [GET /api/users/:id]
 + does not require a session, however:
   * if the provided session represents the user `id`, returns extra data (`email`)
 + **in-url** id (ID) - The user ID to fetch
@@ -1099,7 +1099,7 @@ GET /api/users/1
 ```
 
 <a name='get-user-permissions'></a>
-###### Get a user's permissions [GET /api/users/:id/permissions]
+#### Get a user's permissions [GET /api/users/:id/permissions]
 + **in-url** id (ID) - The user ID to fetch
 
 Returns `{ permissions }`, where `permissions` is a [permissions](#permissions) object.
@@ -1118,21 +1118,21 @@ GET /api/users/1/permissions
 ```
 
 <a name='get-user-channel-permissions'></a>
-###### Get a user's channel-specific permissions [GET /api/users/:userID/channel-permissions/:channelID]
+#### Get a user's channel-specific permissions [GET /api/users/:userID/channel-permissions/:channelID]
 + **in-url** userID (ID) - The user ID to fetch
 + **in-url** channelID (ID) - The channel ID to fetch
 
 Returns `{ permissions }`, where `permissions` is a [permissions](#permissions) object containing permissions, with the given channel's role-specific permissions applied.
 
 <a name='delete-user'></a>
-###### Delete a user [DELETE /api/users/:id]
+#### Delete a user [DELETE /api/users/:id]
 + requires [permission](#permission): `manageUsers`
 + **in-url** id (ID) - The user to delete
 
 Returns `{}` and emits [user/delete](#user-delete).
 
 <a name='check-username-available'></a>
-###### Check if a username is available [GET /api/username-available/:username]
+#### Check if a username is available [GET /api/username-available/:username]
 + does not require session
 + **in-url** username (name)
 
@@ -1162,27 +1162,27 @@ GET /api/username-available/patrick
 
 * [Permissions](#permissions)
 
-**Events**
+### Events
 
 <a name='role-new'></a>
-###### role/new
+#### role/new
 
 Sent to all clients when a role is [added](#new-role). Passed data is in the format `{ role }`.
 
 <a name='role-update'></a>
-###### role/update
+#### role/update
 
 Sent to all clients when a role is [updated](#update-role). Passed data is in the format `{ role }`.
 
 <a name='role-delete'></a>
-###### role/delete
+#### role/delete
 
 Sent to all clients when a role is [deleted](#delete-role). Passed data is in the format `{ roleID }`.
 
-**Endpoints**
+### Endpoints
 
 <a name='list-roles'></a>
-###### List roles [GET /api/roles]
+#### List roles [GET /api/roles]
 
 Returns `{ roles }`, where `roles` is an array of role objects.
 
@@ -1201,12 +1201,12 @@ GET /api/roles
 ```
 
 <a name='get-role-order'></a>
-###### Retrieve role prioritization order [GET /api/roles/order]
+#### Retrieve role prioritization order [GET /api/roles/order]
 
 Returns `{ roleIDs }`, where `roleIDs` is an array of role IDs representing the order that roles are applied when [permissions](#permissions) are calculated. Internal roles, such as `_guest` and `_everyone`, are not included.
 
 <a name='prioritize-roles'></a>
-###### Change role prioritization order [PATCH /api/roles/order]
+#### Change role prioritization order [PATCH /api/roles/order]
 
 + requires [permission](#permissions): `manageRoles`
 + `roleIDs` (array of IDs) - The order roles are applied in
@@ -1240,7 +1240,7 @@ GET /api/roles
 ```
 
 <a name='get-role'></a>
-###### Retrieve a role by ID [GET /api/roles/:id]
+#### Retrieve a role by ID [GET /api/roles/:id]
 
 Returns `{ role }`.
 
@@ -1257,7 +1257,7 @@ GET /api/roles/_everyone
 ```
 
 <a name='new-role'></a>
-###### Add a new role [POST /api/roles]
+#### Add a new role [POST /api/roles]
 + requires [permission](#permissions): `manageRoles`
 + `name` (string) - Max length 32.
 + `permissions` ([Permissions object](#permissions)) - this role's intended permissions
@@ -1266,7 +1266,7 @@ GET /api/roles/_everyone
 Returns `{ roleID }` if successful, where `roleID` is the ID of the new role. Emits [role/new](#role-new). The role is added to the role prioritization order as the most prioritized.
 
 <a name='update-role'></a>
-###### Update a role [PATCH /api/roles/:id]
+#### Update a role [PATCH /api/roles/:id]
 + requires [permission](#permissions): `manageRoles`
 + **in-url** id (ID)
 + `name` (string; optional) - Max length 32.
@@ -1276,7 +1276,7 @@ Returns `{ roleID }` if successful, where `roleID` is the ID of the new role. Em
 Returns `{}` and emits [role/update](#role-update) if successful. May emit [user/update](#user-update) as required if users' computed permissions change.
 
 <a name='delete-role'></a>
-###### Delete a role [DELETE /api/roles/:id]
+#### Delete a role [DELETE /api/roles/:id]
 + requires [permission](#permissions): `manageRoles`
 + **in-url** id (ID string)
 

--- a/doc.md
+++ b/doc.md
@@ -169,7 +169,7 @@ Below is a table of all permissions.
 
 **Endpoints**
 
-### Retrieve server implementation details [GET /api]
+###### Retrieve server implementation details [GET /api]
 Returns `{ decentVersion, implementation, useSecureProtocol }`, where `decentVersion` is a string version number corresponding to the specification version the server supports/providers, `implementation` is a string typically refering to the name of the server impementation, and the boolean `useSecureProtocol` should be `true` when this server is only accessible via the _HTTPS_ and _WSS_ protocols.
 
 Should be used to check to see if a particular server is compatible with the version of the spec that you (the client) support. Note that Decent follows [SemVer](https://semver.org/), so unless the MAJOR (first) portion of the version number is different to what you expect communication should work fine.
@@ -185,7 +185,7 @@ GET /api/
 ```
 
 <a id='upload-image'></a>
-### Upload an image [POST /api/upload-image]
+###### Upload an image [POST /api/upload-image]
 + requires [permission](#permissions): `uploadImages`
 + expects form data (`multipart/form-data`)
   * `image` (gif/jpeg/png) - The image to upload. Max size: 10MB
@@ -218,13 +218,13 @@ This endpoint may return [an error](#errors), namely FAILED, NO, or NOT_ALLOWED.
 **Events**
 
 <a name='server-settings-update'></a>
-## server-settings/update
+###### server-settings/update
 
 Emitted with data `{ settings }` when the server settings are modified.
 
 **Endpoints**
 
-### Retrieve all settings [GET /api/settings]
+###### Retrieve all settings [GET /api/settings]
 Returns `{ settings }`, where `settings` is an object representing server-specific settings.
 
 ```js
@@ -238,7 +238,7 @@ GET /api/settings
 <- }
 ```
 
-### Modify settings [PATCH /api/settings]
+###### Modify settings [PATCH /api/settings]
 + requires [permission](#permissions): `manageServer`
 + `name` (string; optional)
 + `iconURL` (string; optional)
@@ -269,12 +269,12 @@ PATCH /api/settings
 **Events**
 
 <a name='emote-new'></a>
-### emote/new
+###### emote/new
 
 Sent to all clients when an emote is created. Passed data is in the format `{ emote }`.
 
 <a name='emote-delete'></a>
-### emote/delete
+###### emote/delete
 
 Sent to all clients when an emote is deleted. Passed data is in the format `{ shortcode }`.
 
@@ -282,7 +282,7 @@ Sent to all clients when an emote is deleted. Passed data is in the format `{ sh
 **Endpoints**
 
 <a name='list-emotes'></a>
-### List emotes [GET /api/emotes]
+###### List emotes [GET /api/emotes]
 
 Returns `{ emotes }`, where `emotes` is an array of emote objects.
 
@@ -295,7 +295,7 @@ GET /api/emotes
 ```
 
 <a name='new-emote'></a>
-### Add a new emote [POST /api/emotes]
+###### Add a new emote [POST /api/emotes]
 + requires [permission](#permissions): `manageEmotes`
 + `imageURL` (string)
 + `shortcode` (string) - Should not include colons (`:`) or spaces. Must be unique, even if the user has the `allowNonUnique` [permission](#permissions).
@@ -314,7 +314,7 @@ POST /api/emotes
 ```
 
 <a name='view-emote'></a>
-### View an emote [GET /api/emotes/:shortcode]
+###### View an emote [GET /api/emotes/:shortcode]
 + **in-url** shortcode (string)
 
 302 redirects to the `imageURL` of the emote specified. 404s if not found or invalid.
@@ -325,7 +325,7 @@ POST /api/emotes
 ```
 
 <a name='delete-emote'></a>
-### Delete an existing emote [DELETE /api/emotes/:shortcode]
+###### Delete an existing emote [DELETE /api/emotes/:shortcode]
 + requires [permission](#permissions): `manageEmotes`
 + **in-url** shortcode (string)
 
@@ -351,7 +351,7 @@ DELETE /api/emotes/package
 **Endpoints**
 
 <a name='get-sessions'></a>
-### Fetch the current user's sessions [GET /api/sessions]
+###### Fetch the current user's sessions [GET /api/sessions]
 + requires a valid session ID & user
 
 Responds with `{ sessions }`, where `sessions` is an array of [sessions](#sessions) that also represent the user that the provided session represents (the callee; you).
@@ -370,7 +370,7 @@ GET /api/sessions
 ```
 
 <a name='login'></a>
-### Login [POST /api/sessions]
+###### Login [POST /api/sessions]
 + `username` (string)
 + `password` (string)
 
@@ -389,7 +389,7 @@ POST /api/sessions
 <- }
 ```
 
-### Fetch session details [GET /api/sessions/:id]
+###### Fetch session details [GET /api/sessions/:id]
 + does not require a session ID via means other than in the URL
 + **in-url** id (string, session ID)
 
@@ -412,7 +412,7 @@ GET /api/sessions/12345678-ABCDEFGH
 ```
 
 <a name='logout'></a>
-### Logout [DELETE /api/sessions/:id]
+###### Logout [DELETE /api/sessions/:id]
 + does not require a session ID via means other than in the URL
 + **in-url** id (string, session ID)
 
@@ -468,24 +468,24 @@ Mentions target a single user only and are formatted as `<@userID>`, where `user
 **Events**
 
 <a name='message-new'></a>
-### message/new
+###### message/new
 
 Sent to all clients whenever a message is [sent](#send-message) to any channel in the server. Passed data is in the format `{ message }`, where `message` is a [message](#messages) representing the new message.
 
 <a name='message-edit'></a>
-### message/edit
+###### message/edit
 
 Sent to all clients when any message is [edited](#edit-message). Passed data is in the format `{ message }`, where `message` is a [message](#messages) representing the new message.
 
 <a name='message-delete'></a>
-### message/delete
+###### message/delete
 
 Sent to all clients when any message is [deleted](#delete-message). Passed data is in the format `{ messageID }`.
 
 **Endpoints**
 
 <a name='send-message'></a>
-### Send a message [POST /api/messages]
+###### Send a message [POST /api/messages]
 + requires [permissions](#permissions):
   * `sendMessages`
   * `sendSystemMessages`, if `type == "system"`
@@ -509,7 +509,7 @@ POST /api/messages
 ```
 
 <a name='get-message'></a>
-### Retrieve a message [GET /api/messages/:id]
+###### Retrieve a message [GET /api/messages/:id]
 + requires [permission](#permissions): `readMessages`
 + **in-url** id (ID) - The ID of the message to retrieve
 
@@ -527,7 +527,7 @@ GET /api/messages/1234
 ```
 
 <a name='edit-message'></a>
-### Edit a message [PATCH /api/messages/:id]
+###### Edit a message [PATCH /api/messages/:id]
 + requires a session ID where the session user is the author of message `id`
 + **in-url** id (ID) - The ID of the message to edit
 + `text` (string) - The new content of the message
@@ -547,7 +547,7 @@ PATCH /api/messages/1234
 This endpoint will return a NOT_YOURS [error](#errors) if you do not own the message in question. Emits [user/mentions/add](#user-mentions-add) to newly [mentioned](#mentions) users and [user/mentions/remove](#user-mentions-remove) to users who are no longer mentioned, if any.
 
 <a name='delete-message'></a>
-### Delete a message [DELETE /api/messages/:id]
+###### Delete a message [DELETE /api/messages/:id]
 + requires one of:
   * session with ownership of message `id`
   * [permission](#permissions) (for channel of specified message) `deleteMessages`
@@ -575,7 +575,7 @@ This endpoint may return a NOT_YOURS [error](#errors) if you do not own the mess
 ```
 
 <a id='channel-extra-data'></a>
-#### Extra data
+###### Extra data
 This data is only present if a valid, logged-in session ID is provided to channel-returning endpoints.
 ```js
 {
@@ -591,34 +591,34 @@ This data is only present if a valid, logged-in session ID is provided to channe
 **Events**
 
 <a name='channel-new'></a>
-### channel/new
+###### channel/new
 
 Sent to all clients when a channel is [created](#create-channel). Passed data is in the format `{ channel }`, where `channel` is a [channel](#channels) representing the new channel.
 
 <a name='channel-update'></a>
-### channel/update
+###### channel/update
 
 Sent to all clients when a channel is updated ([renamed](#rename-channel), [marked as read](#mark-channel-as-read), etc). Passed data is in the format `{ channel }`, including `channel.unreadMessageCount` if the socket is actively [ponging sessionIDs](#pongdata).
 
 <a name='channel-pins-add'></a>
-### channel/pins/add
+###### channel/pins/add
 
 Sent to all clients when a message is [pinned](#pin) to a channel. Passed data is in the format `{ message }`, where `message` is the message that was pinned.
 
 <a name='channel-pins-remove'></a>
-### channel/pins/remove
+###### channel/pins/remove
 
 Sent to all clients when a message is [unpinned](#unpin) from a channel. Passed data is in the format `{ messageID }`, where `messageID` is the ID of the message that was unpinned.
 
 <a name='channel-delete'></a>
-### channel/delete
+###### channel/delete
 
 Sent to all clients when a channel is [deleted](#delete-channel). Passed data is in the format `{ channelID }`.
 
 **Endpoints**
 
 <a name='channel-list'></a>
-### Get list of channels [GET /api/channels]
+###### Get list of channels [GET /api/channels]
 + does not require session, however:
   * channels where the session user does not have the `readMessages` [permission](#permissions) will not be returned
   * returns [extra data](#channel-extra-data) with session
@@ -639,7 +639,7 @@ GET /api/channels
 ```
 
 <a name='create-channel'></a>
-### Create a channel [POST /api/channels]
+###### Create a channel [POST /api/channels]
 + requires [permission](#permissions) `manageChannels`
 + `name` (name) - The name of the channel.
 
@@ -658,7 +658,7 @@ POST /api/channels
 ```
 
 <a name='get-channel'></a>
-### Retrieve a channel [GET /api/channels/:id]
+###### Retrieve a channel [GET /api/channels/:id]
 + does not require session, however:
   * returns [extra data](#channel-extra-data) with session
 + **in-url** id (ID) - The ID of the channel.
@@ -677,7 +677,7 @@ GET /api/channels/5678
 ```
 
 <a name='rename-channel'></a>
-### Rename a channel [PATCH /api/channels/:id]
+###### Rename a channel [PATCH /api/channels/:id]
 + requires [permission](#permissions) `manageChannels`
 + **in-url** id (ID) - The ID of the channel.
 + name (name) - The new name of the channel
@@ -695,7 +695,7 @@ PATCH /api/channels/5678
 ```
 
 <a name='delete-channel'></a>
-### Delete a channel [DELETE /api/channels/:id]
+###### Delete a channel [DELETE /api/channels/:id]
 + requires [permission](#permissions) `manageChannels`
 + **in-url** id (ID) - The ID of the channel to delete.
 
@@ -708,7 +708,7 @@ DELETE /api/channels/5678
 ```
 
 <a name='mark-channel-as-read'></a>
-### Mark a channel as read [POST /api/channels/:id/mark-read]
+###### Mark a channel as read [POST /api/channels/:id/mark-read]
 + requires [permission](#permissions) (for specified channel) `readMessages`
 + **in-url** id (ID) - The ID of the channel.
 
@@ -721,7 +721,7 @@ POST /api/channels/5678/mark-read
 ```
 
 <a name='get-messages-in-channel'></a>
-### Get messages in channel [GET /api/channels/:id/messages]
+###### Get messages in channel [GET /api/channels/:id/messages]
 + requires [permission](#permissions) (for specified channel) `readMessages`
 + **in-url** id (ID) - The ID of the channel to fetch messages of.
 + `before` (ID; optional) - The ID of the message right **after** the range of messages you want.
@@ -766,7 +766,7 @@ GET /api/channels/5678/messages?after=1234
 ```
 
 <a name='update-channel-permissions'></a>
-### Update channel-specific role permissions [PATCH /api/channels/:id/role-permissions]
+###### Update channel-specific role permissions [PATCH /api/channels/:id/role-permissions]
 + requires [permission](#permissions) (for specified channel) `manageRoles`
 + **in-url** id (ID)
 + **rolePermissions** - an object map of role IDs to their permissions
@@ -793,7 +793,7 @@ PATCH /api/channels/1234/role-permissions
 ```
 
 <a name='get-channel-permissions'></a>
-### Get channel-specific role permissions [GET /api/channels/:id/role-permissions]
+###### Get channel-specific role permissions [GET /api/channels/:id/role-permissions]
 + **in-url** id (ID)
 
 Returns `{ rolePermissions }` if successful, where `rolePermissions` is a map of role IDs to their individual [permissions](#permissions).
@@ -813,7 +813,7 @@ GET /api/channels/1234/role-permissions
 ```
 
 <a name='get-pins'></a>
-### Retrieve all pinned messages [GET /api/channels/:id/pins]
+###### Retrieve all pinned messages [GET /api/channels/:id/pins]
 + requires [permission](#permissions) (for specified channel) `readMessages`
 + **in-url** id (ID)
 
@@ -834,7 +834,7 @@ GET /api/channels/5678/pins
 ```
 
 <a name='pin'></a>
-### Pin a message [POST /api/channels/:id/pins]
+###### Pin a message [POST /api/channels/:id/pins]
 + requires [permission](#permissions) (for specified channel) `managePins`
 + **in-url** id (ID)
 + `messageID` (ID) - The message to pin to this channel.
@@ -852,7 +852,7 @@ POST /api/channels/5678/pins
 ```
 
 <a name='unpin'></a>
-### Unpin a message [DELETE /api/channels/:channelID/pins/:messageID]
+###### Unpin a message [DELETE /api/channels/:channelID/pins/:messageID]
 + requires [permission](#permissions) (for specified channel) `managePins`
 + **in-url** channelID (ID)
 + **in-url** messageID (ID) - The ID of the message to unpin. Errors if not pinned.
@@ -887,37 +887,37 @@ DELETE /api/channels/5678/pins/1234
 **Events**
 
 <a name='user-new'></a>
-### user/new
+###### user/new
 
 Sent to all clients when a user is created. Passed data is in the format `{ user }`.
 
 <a name='user-delete'></a>
-### user/delete
+###### user/delete
 
 Sent to all clients when a user is deleted. Passed data is in the format `{ userID }`.
 
 <a name='user-online'></a>
-### user/online
+###### user/online
 
 Sent to all clients when a user becomes online. This is whenever a socket [tells the server](#pongdata) that its session ID is that of a user who was not already online before. Passed data is in the format `{ userID }`.
 
 <a name='user-offline'></a>
-### user/offline
+###### user/offline
 
 Sent to all clients when a user becomes offline. This is whenever the last socket of a user who is online terminates. Passed data is in the format `{ userID }`.
 
 <a name='user-update'></a>
-### user/update
+###### user/update
 
 Sent to all clients when a user is mutated using [PATCH /api/users/:userID](#update-user). Passed data is in the format `{ user }`.
 
 <a name='user-mentions-add'></a>
-### user/mentions/add
+###### user/mentions/add
 
 When a user is [mentioned](#mentions), this is sent to all sockets authenticated as them. Passed data is in the format `{ message }`, where `message` is the new / just edited mesage that mentioned the user.
 
 <a name='user-mentions-remove'></a>
-### user/mentions/remove
+###### user/mentions/remove
 
 When a message is deleted or edited to remove [the mention of a user](#mentions), all sockets authenticated as the unmentioned user are sent this event. Passed data is in the format `{ messageID }`, where `messageID` is the ID of the message that just stopped mentioning the user.
 
@@ -956,7 +956,7 @@ GET /api/users?sessionID=adminsid123
 ```
 
 <a name='register'></a>
-### Register (create new user) [POST /api/users]
+###### Register (create new user) [POST /api/users]
 + `username` ([name](#names)) - Must be unique
 + `password` (string) - Errors if shorter than 6 characters
 
@@ -980,7 +980,7 @@ POST /api/users
 ```
 
 <a name='get-user'></a>
-### Retrieve a user by ID [GET /api/users/:id]
+###### Retrieve a user by ID [GET /api/users/:id]
 + does not require a valid session, howerver:
   * returns extra data (`email`) if the provided session represents the user requested
 + **in-url** id (ID) - The user ID to fetch
@@ -1000,7 +1000,7 @@ GET /api/users/1
 ```
 
 <a name='get-mentions'></a>
-### List [mentions](#mentions) of a user [GET /api/users/:id/mentions]
+###### List [mentions](#mentions) of a user [GET /api/users/:id/mentions]
 + does not require session, however:
   * only returns messages where you have the `viewMessages` [permission](#permissions) for the message's channel
 + **in-url** id (ID) - The user ID to fetch the mentions of
@@ -1027,7 +1027,7 @@ GET /api/users/1/mentions?limit=1
 ```
 
 <a name='update-user'></a>
-### Update user details [PATCH /api/users/:id]
+###### Update user details [PATCH /api/users/:id]
 + requires valid, logged-in session (see below)
 + **in-url** id (ID) - The user ID to patch
 
@@ -1079,7 +1079,7 @@ PATCH /api/users/12
 ```
 
 <a name='get-user'></a>
-### Retrieve a user by ID [GET /api/users/:id]
+###### Retrieve a user by ID [GET /api/users/:id]
 + does not require a session, however:
   * if the provided session represents the user `id`, returns extra data (`email`)
 + **in-url** id (ID) - The user ID to fetch
@@ -1099,7 +1099,7 @@ GET /api/users/1
 ```
 
 <a name='get-user-permissions'></a>
-### Get a user's permissions [GET /api/users/:id/permissions]
+###### Get a user's permissions [GET /api/users/:id/permissions]
 + **in-url** id (ID) - The user ID to fetch
 
 Returns `{ permissions }`, where `permissions` is a [permissions](#permissions) object.
@@ -1118,21 +1118,21 @@ GET /api/users/1/permissions
 ```
 
 <a name='get-user-channel-permissions'></a>
-### Get a user's channel-specific permissions [GET /api/users/:userID/channel-permissions/:channelID]
+###### Get a user's channel-specific permissions [GET /api/users/:userID/channel-permissions/:channelID]
 + **in-url** userID (ID) - The user ID to fetch
 + **in-url** channelID (ID) - The channel ID to fetch
 
 Returns `{ permissions }`, where `permissions` is a [permissions](#permissions) object containing permissions, with the given channel's role-specific permissions applied.
 
 <a name='delete-user'></a>
-### Delete a user [DELETE /api/users/:id]
+###### Delete a user [DELETE /api/users/:id]
 + requires [permission](#permission): `manageUsers`
 + **in-url** id (ID) - The user to delete
 
 Returns `{}` and emits [user/delete](#user-delete).
 
 <a name='check-username-available'></a>
-### Check if a username is available [GET /api/username-available/:username]
+###### Check if a username is available [GET /api/username-available/:username]
 + does not require session
 + **in-url** username (name)
 
@@ -1165,24 +1165,24 @@ GET /api/username-available/patrick
 **Events**
 
 <a name='role-new'></a>
-### role/new
+###### role/new
 
 Sent to all clients when a role is [added](#new-role). Passed data is in the format `{ role }`.
 
 <a name='role-update'></a>
-### role/update
+###### role/update
 
 Sent to all clients when a role is [updated](#update-role). Passed data is in the format `{ role }`.
 
 <a name='role-delete'></a>
-### role/delete
+###### role/delete
 
 Sent to all clients when a role is [deleted](#delete-role). Passed data is in the format `{ roleID }`.
 
 **Endpoints**
 
 <a name='list-roles'></a>
-### List roles [GET /api/roles]
+###### List roles [GET /api/roles]
 
 Returns `{ roles }`, where `roles` is an array of role objects.
 
@@ -1201,12 +1201,12 @@ GET /api/roles
 ```
 
 <a name='get-role-order'></a>
-### Retrieve role prioritization order [GET /api/roles/order]
+###### Retrieve role prioritization order [GET /api/roles/order]
 
 Returns `{ roleIDs }`, where `roleIDs` is an array of role IDs representing the order that roles are applied when [permissions](#permissions) are calculated. Internal roles, such as `_guest` and `_everyone`, are not included.
 
 <a name='prioritize-roles'></a>
-### Change role prioritization order [PATCH /api/roles/order]
+###### Change role prioritization order [PATCH /api/roles/order]
 
 + requires [permission](#permissions): `manageRoles`
 + `roleIDs` (array of IDs) - The order roles are applied in
@@ -1240,7 +1240,7 @@ GET /api/roles
 ```
 
 <a name='get-role'></a>
-### Retrieve a role by ID [GET /api/roles/:id]
+###### Retrieve a role by ID [GET /api/roles/:id]
 
 Returns `{ role }`.
 
@@ -1257,7 +1257,7 @@ GET /api/roles/_everyone
 ```
 
 <a name='new-role'></a>
-### Add a new role [POST /api/roles]
+###### Add a new role [POST /api/roles]
 + requires [permission](#permissions): `manageRoles`
 + `name` (string) - Max length 32.
 + `permissions` ([Permissions object](#permissions)) - this role's intended permissions
@@ -1266,7 +1266,7 @@ GET /api/roles/_everyone
 Returns `{ roleID }` if successful, where `roleID` is the ID of the new role. Emits [role/new](#role-new). The role is added to the role prioritization order as the most prioritized.
 
 <a name='update-role'></a>
-### Update a role [PATCH /api/roles/:id]
+###### Update a role [PATCH /api/roles/:id]
 + requires [permission](#permissions): `manageRoles`
 + **in-url** id (ID)
 + `name` (string; optional) - Max length 32.
@@ -1276,7 +1276,7 @@ Returns `{ roleID }` if successful, where `roleID` is the ID of the new role. Em
 Returns `{}` and emits [role/update](#role-update) if successful. May emit [user/update](#user-update) as required if users' computed permissions change.
 
 <a name='delete-role'></a>
-### Delete a role [DELETE /api/roles/:id]
+###### Delete a role [DELETE /api/roles/:id]
 + requires [permission](#permissions): `manageRoles`
 + **in-url** id (ID string)
 

--- a/doc.md
+++ b/doc.md
@@ -167,7 +167,7 @@ Below is a table of all permissions.
 
 ## Miscellaneous
 
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 ### Retrieve server implementation details [GET /api]
 Returns `{ decentVersion, implementation, useSecureProtocol }`, where `decentVersion` is a string version number corresponding to the specification version the server supports/providers, `implementation` is a string typically refering to the name of the server impementation, and the boolean `useSecureProtocol` should be `true` when this server is only accessible via the _HTTPS_ and _WSS_ protocols.
@@ -204,7 +204,7 @@ POST /api/upload-image
 
 This endpoint may return [an error](#errors), namely FAILED, NO, or NOT_ALLOWED.
 
-</details>
+---
 
 ## Settings
 
@@ -215,16 +215,14 @@ This endpoint may return [an error](#errors), namely FAILED, NO, or NOT_ALLOWED.
 }
 ```
 
-<details><summary>Events</summary>
+**Events**
 
 <a name='server-settings-update'></a>
 ## server-settings/update
 
 Emitted with data `{ settings }` when the server settings are modified.
 
-</details>
-
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 ### Retrieve all settings [GET /api/settings]
 Returns `{ settings }`, where `settings` is an object representing server-specific settings.
@@ -257,7 +255,7 @@ PATCH /api/settings
 <- {}
 ```
 
-</details>
+---
 
 ## Emotes
 
@@ -268,7 +266,7 @@ PATCH /api/settings
 }
 ```
 
-<details><summary>Events</summary>
+**Events**
 
 <a name='emote-new'></a>
 ### emote/new
@@ -280,9 +278,8 @@ Sent to all clients when an emote is created. Passed data is in the format `{ em
 
 Sent to all clients when an emote is deleted. Passed data is in the format `{ shortcode }`.
 
-</details>
 
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 <a name='list-emotes'></a>
 ### List emotes [GET /api/emotes]
@@ -340,7 +337,7 @@ DELETE /api/emotes/package
 <- {}
 ```
 
-</details>
+---
 
 ## Sessions
 
@@ -351,7 +348,7 @@ DELETE /api/emotes/package
 }
 ```
 
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 <a name='get-sessions'></a>
 ### Fetch the current user's sessions [GET /api/sessions]
@@ -427,7 +424,7 @@ DELETE /api/sessions/12345678-ABCDEFGH
 <- {}
 ```
 
-</details>
+---
 
 ## Messages
 
@@ -468,7 +465,7 @@ System messages lack `author` fields.
 
 Mentions target a single user only and are formatted as `<@userID>`, where `userID` is the ID of the user who is being mentioned. Mentions are stored per-user on the server. `mentionedUserIDs` is derived from the content of the message.
 
-<details><summary>Events</summary>
+**Events**
 
 <a name='message-new'></a>
 ### message/new
@@ -485,9 +482,7 @@ Sent to all clients when any message is [edited](#edit-message). Passed data is 
 
 Sent to all clients when any message is [deleted](#delete-message). Passed data is in the format `{ messageID }`.
 
-</details>
-
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 <a name='send-message'></a>
 ### Send a message [POST /api/messages]
@@ -568,7 +563,7 @@ DELETE /api/messages/1234
 
 This endpoint may return a NOT_YOURS [error](#errors) if you do not own the message in question. Note that admins may delete any message. Emits [user/mentions/remove](#user-mentions-remove) to all previously-[mentioned](#mentions) users.
 
-</details>
+---
 
 ## Channels
 
@@ -593,7 +588,7 @@ This data is only present if a valid, logged-in session ID is provided to channe
 }
 ```
 
-<details><summary>Events</summary>
+**Events**
 
 <a name='channel-new'></a>
 ### channel/new
@@ -620,9 +615,7 @@ Sent to all clients when a message is [unpinned](#unpin) from a channel. Passed 
 
 Sent to all clients when a channel is [deleted](#delete-channel). Passed data is in the format `{ channelID }`.
 
-</details>
-
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 <a name='channel-list'></a>
 ### Get list of channels [GET /api/channels]
@@ -872,7 +865,7 @@ DELETE /api/channels/5678/pins/1234
 <- {}
 ```
 
-</details>
+---
 
 ## Users
 
@@ -891,7 +884,7 @@ DELETE /api/channels/5678/pins/1234
 }
 ```
 
-<details><summary>Events</summary>
+**Events**
 
 <a name='user-new'></a>
 ### user/new
@@ -928,9 +921,7 @@ When a user is [mentioned](#mentions), this is sent to all sockets authenticated
 
 When a message is deleted or edited to remove [the mention of a user](#mentions), all sockets authenticated as the unmentioned user are sent this event. Passed data is in the format `{ messageID }`, where `messageID` is the ID of the message that just stopped mentioning the user.
 
-</details>
-
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 <a name='user-list'></a>
 ### Fetch users [GET /api/users]
@@ -1155,7 +1146,7 @@ GET /api/username-available/patrick
 <- }
 ```
 
-</details>
+---
 
 ## Roles
 
@@ -1171,7 +1162,7 @@ GET /api/username-available/patrick
 
 * [Permissions](#permissions)
 
-<details><summary>Events</summary>
+**Events**
 
 <a name='role-new'></a>
 ### role/new
@@ -1188,9 +1179,7 @@ Sent to all clients when a role is [updated](#update-role). Passed data is in th
 
 Sent to all clients when a role is [deleted](#delete-role). Passed data is in the format `{ roleID }`.
 
-</details>
-
-<details><summary>Endpoints</summary>
+**Endpoints**
 
 <a name='list-roles'></a>
 ### List roles [GET /api/roles]
@@ -1293,4 +1282,4 @@ Returns `{}` and emits [role/update](#role-update) if successful. May emit [user
 
 Returns `{}` if successful. Emits [role/delete](#role-delete). The role is removed from the role prioritization order.
 
-</details>
+---

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+toc:
+	# npm install --global markdown-toc
+	markdown-toc doc.md -i
+	markdown-toc spec.md -i

--- a/spec.md
+++ b/spec.md
@@ -4,28 +4,32 @@
 |:-------------:| --------------- |
 |               | Not yet         |
 
-* [1.](#1-introduction) Introduction
-  * [1.1](#11-about) About
-  * [1.2](#12-terminology) Terminology
-  * [1.3](#13-data-types) Data types
-* [2.](#2-http-request-protocol) HTTP request protocol
-  * [2.1](#21-content-type) Content-type
-  * [2.2](#22-routing) Routing
-  * [2.3](#23-error-responses) Error responses
-  * [2.4](#24-session-ids-and-authentication) Session IDs and authentication
-  * [2.5](#25-permissions-and-roles) Permissions and roles
-* [3.](#3-bidirectional-websocket-communication) Bidirectional WebSocket communication
-  * [3.1](#31-websocket-protocol) WebSocket protocol
-  * [3.2](#32-pingdata-and-pongdata-events) "pingdata" and "pongdata" events
-  * [3.3](#33-useronline-and-useroffline-events) "user/online" and "user/offline" events
-* [4.](#4-api-endpoints-and-events) API endpoints and events
-  * [4.1](#41-miscellaneous) Miscellaneous
-  * [4.2](#42-user-related) User-related
-  * [4.3](#43-role-related) Role-related
-  * [4.4](#44-message-related) Message-related
-  * [4.5](#45-channel-related) Channel-related
-  * [4.6](#46-emote-related) Emote-related
-  * [4.7](#47-session-related) Session-related
+<!-- toc -->
+
+  * [1. Introduction](#1-introduction)
+    + [1.1 About](#11-about)
+    + [1.2 Terminology](#12-terminology)
+    + [1.3 Data types](#13-data-types)
+  * [2. HTTP request protocol](#2-http-request-protocol)
+    + [2.1 Content type](#21-content-type)
+    + [2.2 Routing](#22-routing)
+    + [2.3 Error responses](#23-error-responses)
+    + [2.4 Session IDs and authentication](#24-session-ids-and-authentication)
+    + [2.5 Permissions and roles](#25-permissions-and-roles)
+  * [3. Bidirectional WebSocket communication](#3-bidirectional-websocket-communication)
+    + [3.1 WebSocket protocol](#31-websocket-protocol)
+    + [3.2 "pingdata" and "pongdata" events](#32-pingdata-and-pongdata-events)
+    + [3.3 "user/online" and "user/offline" events](#33-useronline-and-useroffline-events)
+- [4. API endpoints and events](#4-api-endpoints-and-events)
+  * [4.1 Miscellaneous](#41-miscellaneous)
+  * [4.2 User-related](#42-user-related)
+  * [4.3 Role-related](#43-role-related)
+  * [4.4 Message-related](#44-message-related)
+  * [4.5 Channel-related](#45-channel-related)
+  * [4.6 Emote-related](#46-emote-related)
+  * [4.7 Session-related](#47-session-related)
+
+<!-- tocstop -->
 
 ## 1. Introduction
 


### PR DESCRIPTION
Uses [markdown-toc](https://npm.im/markdown-toc) to regenerate a table of contents for both documents when you run `make toc`.

Opinions on including everything, including individual endpoints, in the TOC? We can configure it to not include H4s.

**This PR includes #10.**