### PR TITLE
Make GET /api/emotes/:shortcode public

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -431,6 +431,7 @@ POST /api/emotes
 
 <a name='view-emote'></a>
 #### View an emote [GET /api/emotes/:shortcode]
++ never requires a session (public endpoint)
 + **in-url** shortcode (string)
 
 302 redirects to the `imageURL` of the emote specified. 404s if not found or invalid.


### PR DESCRIPTION
Paving the way for client-side global emotes (`:woah+server.com:` or similar)!

![image](https://user-images.githubusercontent.com/9429556/39680278-b15d473c-5196-11e8-969d-fa3d5f371559.png)
