### PR TITLE
Define internal roles and limit channel-specific permission overrides

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -286,7 +286,7 @@ overrides:
 
 | Name                 | Change in meaning |
 | -------------------- | ----------------- |
-| `manageChannels`     | Applies to the current channel only |
+| `manageChannels`     | Allows changes to the role permission overrides of this channel |
 | `readMessages`       | If `false`, the channel will not appear in the channel list for you |
 | `sendMessages`       | |
 | `deleteMessages`     | |
@@ -896,7 +896,7 @@ GET /api/channels/5678/messages?after=1234
 
 <a name='update-channel-permissions'></a>
 #### Update channel-specific role permissions [PATCH /api/channels/:id/role-permissions]
-+ requires [permission](#permissions) (for specified channel) `manageRoles`
++ requires [permission](#permissions) (for specified channel) `manageChannels`
 + **in-url** id (ID)
 + **rolePermissions** - an object map of role IDs to their permissions, limited by [channel-specific applicable permissions only](#channel-specific-permissions)
 

--- a/doc.md
+++ b/doc.md
@@ -23,6 +23,8 @@ implementation, please refer to that document also.**
     + ['pongdata' event](#pongdata-event)
 - [Errors](#errors)
 - [Permissions](#permissions)
+  * [Permission table](#permission-table)
+  * [Channel-specific permissions](#channel-specific-permissions)
 - [Miscellaneous](#miscellaneous)
   * [Endpoints](#endpoints)
     + [Retrieve server implementation details [GET /api]](#retrieve-server-implementation-details-get-api)

--- a/doc.md
+++ b/doc.md
@@ -284,11 +284,13 @@ Below is a table of all permissions.
 **Only** the following permissions are applicable as channel-specific permission
 overrides:
 
+| Name                 | Change in meaning |
+| -------------------- | ----------------- |
 | `manageChannels`     | Applies to the current channel only |
 | `readMessages`       | If `false`, the channel will not appear in the channel list for you |
-| `sendMessages`       ||
-| `deleteMessages`     ||
-| `sendSystemMessages` ||
+| `sendMessages`       | |
+| `deleteMessages`     | |
+| `sendSystemMessages` | |
 
 <a name='api'></a>
 

--- a/doc.md
+++ b/doc.md
@@ -1365,7 +1365,7 @@ Returns `{ roleIDs }`, where `roleIDs` is an array of role IDs representing the 
 
 + requires [permission](#permissions): `manageRoles`
 + `roleIDs` (array of IDs) - The order roles are applied in
-  * Must contain all role IDs exactly once (no more, no less), except for [internal roles](spec.md#internal-roles) such as `_user` and `_everyone`
+  * Must contain all non-[internal](spec.md#internal-roles) role IDs exactly once (no more, no less)
 
 Returns `{}` when successful. Changes the order that roles are applied in; initial items are the most prioritized. See [Permissions](#permissions).
 

--- a/spec.md
+++ b/spec.md
@@ -197,24 +197,14 @@ Permissions are stored within an object mapping permission key to
 | `undefined` | Unset, follow cascade  |
 
 For example, a role that grants the `sendMessages` permission but changes
-nothing else would have the permission object:
+nothing else would have the following permission object.
 
-  {
-    "sendMessages": true
-  }
+    {
+      "sendMessages": true
+    }
 
-There are 2 constant role IDs that servers MUST apply based on whether the
-requester provided a session ID or not (see section 2.4):
-
-* `_user`, applied to all logged-in users as a fallback role
-* `_everyone`, applied to **all** requesters
-
-Servers MUST NOT allow any of these constant roles to be deleted. However,
-they SHOULD be editable (that is, their permissions object and name).
-
-Note: Servers MAY give a particular group of users some kind of automatically
-generated 'administrator' role to allow changes to be made by the owner of the
-server without manually editing the database or similar.
+See [the permission table](doc.md#permission-table) for a list of all permissions
+and their meanings.
 
 Individual permissions MUST be computed according to the following algorithm.
 
@@ -233,8 +223,8 @@ a NOT_ALLOWED error (and, therefore, be a no-op).
 The order of `r` (role priority) MUST be sorted in the following way:
 
 * Channel-specific permissions for roles of the user (First.)
-* Channel-specific permissions for the `_user` role, if the user is a logged-in member of the server
-* Channel-specific permissions for the `_everyone` role
+* Channel-specific permissions for the [internal `_user` role](#internal-roles), if the user is a logged-in member of the server
+* Channel-specific permissions for the [internal `_everyone` role](#internal-roles)
 * Server-wide permissions for roles of the user
 * Server-wide permissions for the `_user` role (if applicable, as above)
 * Server-wide permissions for the `_everyone` role (Last.)
@@ -244,6 +234,28 @@ MUST be prioritized according to the role prioritization order (see
 `PATCH /api/roles/order` in section 4.3). Note that the order of any given
 user's `roles` property MUST NOT have any effect on the order roles are
 applied when calculating their permissions.
+
+#### Internal roles
+
+This specification defines **two** 'internal roles.' That is, they are applied
+under-the-hood to users under different circumstances. They are:
+
+| role.id   | role.permissions         | Applied to            |
+| --------- | ------------------------ | --------------------- |
+| _everyone | All `false`              | All requests          |
+| _user     | `{ sendMessages: true }` | Any logged-in request |
+
+Servers MUST apply based on whether the requester provided a valid session ID or
+not (see section 2.4):
+
+Servers MUST NOT allow any of these constant roles to be deleted, or updated at
+a global level. However, either role's permissions MUST be
+[editable on a channel-specific basis](doc.md#update-channel-permissions).
+
+> Note: Servers MAY give a particular group of users some kind of automatically
+> generated 'administrator' role to allow changes to be made by the owner of the
+> server without manually editing the database. These roles are **not** classed
+> as internal.
 
 ## 3. Bidirectional WebSocket communication
 

--- a/spec.md
+++ b/spec.md
@@ -16,6 +16,7 @@
     + [2.3 Error responses](#23-error-responses)
     + [2.4 Session IDs and authentication](#24-session-ids-and-authentication)
     + [2.5 Permissions and roles](#25-permissions-and-roles)
+      - [Internal roles](#internal-roles)
   * [3. Bidirectional WebSocket communication](#3-bidirectional-websocket-communication)
     + [3.1 WebSocket protocol](#31-websocket-protocol)
     + [3.2 "pingdata" and "pongdata" events](#32-pingdata-and-pongdata-events)


### PR DESCRIPTION
Adds some stuff we missed with permissions/roles that I noticed while implementing them in `@decent/server`.